### PR TITLE
Simulate in parent

### DIFF
--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -20,6 +20,7 @@ public:
     double getZenith() const;
     double getOpticalDistance() const;
     double getTransmittance() const;
+    void update();
 
 private:
     global::Direction direction;

--- a/include/Entanglement.hpp
+++ b/include/Entanglement.hpp
@@ -13,9 +13,6 @@ public:
     Entanglement(const Device &alice, const Atmosphere *alice_atmosphere, const Device &bob, const Atmosphere *bob_atmosphere, const double heightAboveSeaLevel = 200.0, const double deviationRangeHeight = 0.0, const double deviationRangeLateral = 0.0);
     ~Entanglement();
 
-    // void simulateDoubleSatelliteDefault(double precision) override;
-    // void simulateTripleSatelliteDefault(double precision) override;
-
     // void simulateSingleSatelliteUplink(double precision);
     
     void initChannels(Device &satellite) override;

--- a/include/Entanglement.hpp
+++ b/include/Entanglement.hpp
@@ -13,11 +13,16 @@ public:
     Entanglement(const Device &alice, const Atmosphere *alice_atmosphere, const Device &bob, const Atmosphere *bob_atmosphere, const double heightAboveSeaLevel = 200.0, const double deviationRangeHeight = 0.0, const double deviationRangeLateral = 0.0);
     ~Entanglement();
 
-    void simulateSingleSatelliteDefault(double precision) override;
     void simulateDoubleSatelliteDefault(double precision) override;
     void simulateTripleSatelliteDefault(double precision) override;
 
     void simulateSingleSatelliteUplink(double precision);
+
+    std::string getType() const override;
+    void initChannels(Device &satellite) override;
+    void initChannels(Device &satellite1, Device &satellite2) override;
+    void initChannels(Device &satellite1, Device &satellite2, Device &satellite3) override;
+
 
 private:
     double getQBER() const override;

--- a/include/Entanglement.hpp
+++ b/include/Entanglement.hpp
@@ -14,13 +14,14 @@ public:
     ~Entanglement();
 
     // void simulateSingleSatelliteUplink(double precision);
-    
+
     void initChannels(Device &satellite) override;
     void initChannels(Device &satellite1, Device &satellite2) override;
     void initChannels(Device &satellite1, Device &satellite2, Device &satellite3) override;
 
 private:
     double getQBER() const override;
+    std::string getType() const override;
 };
 
 #endif

--- a/include/Entanglement.hpp
+++ b/include/Entanglement.hpp
@@ -13,20 +13,17 @@ public:
     Entanglement(const Device &alice, const Atmosphere *alice_atmosphere, const Device &bob, const Atmosphere *bob_atmosphere, const double heightAboveSeaLevel = 200.0, const double deviationRangeHeight = 0.0, const double deviationRangeLateral = 0.0);
     ~Entanglement();
 
-    void simulateDoubleSatelliteDefault(double precision) override;
-    void simulateTripleSatelliteDefault(double precision) override;
+    // void simulateDoubleSatelliteDefault(double precision) override;
+    // void simulateTripleSatelliteDefault(double precision) override;
 
-    void simulateSingleSatelliteUplink(double precision);
-
-    std::string getType() const override;
+    // void simulateSingleSatelliteUplink(double precision);
+    
     void initChannels(Device &satellite) override;
     void initChannels(Device &satellite1, Device &satellite2) override;
     void initChannels(Device &satellite1, Device &satellite2, Device &satellite3) override;
 
-
 private:
     double getQBER() const override;
-    static std::string m_type;
 };
 
 #endif

--- a/include/Network.hpp
+++ b/include/Network.hpp
@@ -26,13 +26,12 @@ public:
     void updateChannels();
 
     std::string getType() const;
-
-protected:
-    std::string m_type = "network";
-
     void simulateSingleSatellite(double precision);
     // void simulateDoubleSatelliteDefault(double precision) = 0;
     // void simulateTripleSatelliteDefault(double precision) = 0;
+
+protected:
+    std::string m_type = "network";
     virtual double getQBER() const = 0;
     
     virtual void initChannels(Device &satellite) = 0;

--- a/include/Network.hpp
+++ b/include/Network.hpp
@@ -27,8 +27,8 @@ public:
 
     std::string getType() const;
     void simulateSingleSatellite(double precision);
-    // void simulateDoubleSatelliteDefault(double precision) = 0;
-    // void simulateTripleSatelliteDefault(double precision) = 0;
+    void simulateDoubleSatellite(double precision);
+    void simulateTripleSatellite(double precision);
 
 protected:
     std::string m_type = "network";

--- a/include/Network.hpp
+++ b/include/Network.hpp
@@ -25,14 +25,14 @@ public:
     void deleteChannels();
     void updateChannels();
 
-    virtual std::string getType() const = 0;
+    std::string getType() const;
 
 protected:
-    static std::string type;
+    std::string m_type = "network";
 
     void simulateSingleSatellite(double precision);
-    virtual void simulateDoubleSatelliteDefault(double precision) = 0;
-    virtual void simulateTripleSatelliteDefault(double precision) = 0;
+    // void simulateDoubleSatelliteDefault(double precision) = 0;
+    // void simulateTripleSatelliteDefault(double precision) = 0;
     virtual double getQBER() const = 0;
     
     virtual void initChannels(Device &satellite) = 0;

--- a/include/Network.hpp
+++ b/include/Network.hpp
@@ -22,14 +22,23 @@ public:
     void addChannel(Channel *channel);
     void deleteChannel(Channel *channel);
 
+    void deleteChannels();
+    void updateChannels();
+
+    virtual std::string getType() const = 0;
+
 protected:
     static std::string type;
 
-    virtual void simulateSingleSatelliteDefault(double precision) = 0;
+    void simulateSingleSatellite(double precision);
     virtual void simulateDoubleSatelliteDefault(double precision) = 0;
     virtual void simulateTripleSatelliteDefault(double precision) = 0;
     virtual double getQBER() const = 0;
-
+    
+    virtual void initChannels(Device &satellite) = 0;
+    virtual void initChannels(Device &satellite1, Device &satellite2) = 0;
+    virtual void initChannels(Device &satellite1, Device &satellite2, Device &satellite3) = 0;
+    
     bool dataLogger(const std::string &filename, const std::string &directory, const std::vector<double> &data);
     std::string makeFolder(const char *prefix, const double heightAboveSeaLevel, const std::string &technology);
 
@@ -47,3 +56,5 @@ protected:
 };
 
 #endif
+
+// TODO:: rethink private and public members visibility

--- a/include/Network.hpp
+++ b/include/Network.hpp
@@ -24,15 +24,14 @@ public:
 
     void deleteChannels();
     void updateChannels();
-
-    std::string getType() const;
+    
     void simulateSingleSatellite(double precision);
     void simulateDoubleSatellite(double precision);
     void simulateTripleSatellite(double precision);
 
 protected:
-    std::string m_type = "network";
     virtual double getQBER() const = 0;
+    virtual std::string getType() const = 0;
     
     virtual void initChannels(Device &satellite) = 0;
     virtual void initChannels(Device &satellite1, Device &satellite2) = 0;

--- a/include/PrepareAndMeasure.hpp
+++ b/include/PrepareAndMeasure.hpp
@@ -12,10 +12,7 @@ class PrepareAndMeasure : public Network
 public:
     PrepareAndMeasure(const Device &alice, const Atmosphere *alice_atmosphere, const Device &bob, const Atmosphere *bob_atmosphere, const double heightAboveSeaLevel = 200.0, const double deviationRangeHeight = 0.0, const double deviationRangeLateral = 0.0);
     ~PrepareAndMeasure();
-
-    // void simulateDoubleSatelliteDefault(double precision) override;
-    // void simulateTripleSatelliteDefault(double precision) override;
-
+    
     void initChannels(Device &satellite) override;
     void initChannels(Device &satellite1, Device &satellite2) override;
     void initChannels(Device &satellite1, Device &satellite2, Device &satellite3) override;

--- a/include/PrepareAndMeasure.hpp
+++ b/include/PrepareAndMeasure.hpp
@@ -13,12 +13,15 @@ public:
     PrepareAndMeasure(const Device &alice, const Atmosphere *alice_atmosphere, const Device &bob, const Atmosphere *bob_atmosphere, const double heightAboveSeaLevel = 200.0, const double deviationRangeHeight = 0.0, const double deviationRangeLateral = 0.0);
     ~PrepareAndMeasure();
 
-    void simulateDoubleSatelliteDefault(double precision) override;
-    void simulateTripleSatelliteDefault(double precision) override;
+    // void simulateDoubleSatelliteDefault(double precision) override;
+    // void simulateTripleSatelliteDefault(double precision) override;
+
+    void initChannels(Device &satellite) override;
+    void initChannels(Device &satellite1, Device &satellite2) override;
+    void initChannels(Device &satellite1, Device &satellite2, Device &satellite3) override;
 
 private:
     double getQBER() const override;
-    static std::string m_type;
 };
 
 #endif

--- a/include/PrepareAndMeasure.hpp
+++ b/include/PrepareAndMeasure.hpp
@@ -13,7 +13,6 @@ public:
     PrepareAndMeasure(const Device &alice, const Atmosphere *alice_atmosphere, const Device &bob, const Atmosphere *bob_atmosphere, const double heightAboveSeaLevel = 200.0, const double deviationRangeHeight = 0.0, const double deviationRangeLateral = 0.0);
     ~PrepareAndMeasure();
 
-    void simulateSingleSatelliteDefault(double precision) override;
     void simulateDoubleSatelliteDefault(double precision) override;
     void simulateTripleSatelliteDefault(double precision) override;
 

--- a/include/PrepareAndMeasure.hpp
+++ b/include/PrepareAndMeasure.hpp
@@ -19,6 +19,7 @@ public:
 
 private:
     double getQBER() const override;
+    std::string getType() const override;
 };
 
 #endif

--- a/source/Channel.cpp
+++ b/source/Channel.cpp
@@ -7,40 +7,12 @@
 // Throws a std::runtime_error if an error occurs during initialization.
 Channel::Channel(const Device &initiator, const Device &receiver, const Atmosphere *atmosphere):
     m_initiator(initiator), m_receiver(receiver), m_atmosphere(atmosphere){
-        try {
-            initDirection();
-        } catch (const std::runtime_error &e){
-            global::LOG(e.what());
-            exit(1);
-        }
-
-        initTheta();
-        initDeltaHeight();
-
-        try {
-            initOpticalDistance();
-        } catch (const std::runtime_error &e){
-            throw std::runtime_error("ERROR: unable to initialize channel ( devices are out of sight )");
-        }
-
-        initSurfaceDistance();
-
-        try {
-            initZenith();
-        } catch (const std::range_error &e){
-            throw std::runtime_error("ERROR: communication is insecure ( zenith is too large )");
-        }
-
-        initOpticalSectors();
-
-        try {
-            initTransmittance();
-        } catch (const std::runtime_error &e){
-            global::LOG(e.what());
-            exit(1);
-        }
-
-        initQuantumBitErrorRate();
+    try {
+        initDirection();
+    } catch (const std::runtime_error &e){
+        global::LOG(e.what());
+        exit(1);
+    }
 }
 
 Channel::Channel(const Device &initiator, const Device &receiver):
@@ -52,14 +24,15 @@ Channel::Channel(const Device &initiator, const Device &receiver):
         global::LOG(e.what());
         exit(1);
     }
+}
 
-    if (direction != global::space){
-        global::LOG("ERROR: can not use Channel(cosnt &Device, const &Device) with bases");
-        exit(1);
-    }
+Channel::~Channel() {
+}
+
+void Channel::update() {
 
     initTheta();
-    initDeltaHeight();
+	initDeltaHeight();
 
     try {
         initOpticalDistance();
@@ -67,20 +40,27 @@ Channel::Channel(const Device &initiator, const Device &receiver):
         throw std::runtime_error("ERROR: unable to initialize channel ( devices are out of sight )");
     }
 
-    initSurfaceDistance();
-    initOpticalSectors();
 
-    try {
+	initSurfaceDistance();
+
+	if (direction != global::space) {
+		try {
+		   initZenith();
+		} catch (const std::range_error &e){
+			throw std::runtime_error("ERROR: communication is insecure ( zenith is too large )");
+		}
+	}
+
+	initOpticalSectors();
+
+	try {
         initTransmittance();
     } catch (const std::runtime_error &e){
         global::LOG(e.what());
         exit(1);
     }
 
-    initQuantumBitErrorRate();
-}
-
-Channel::~Channel() {
+	initQuantumBitErrorRate();	
 }
 
 void Channel::initDirection() {

--- a/source/Entanglement.cpp
+++ b/source/Entanglement.cpp
@@ -21,251 +21,34 @@ double Entanglement::getQBER() const {
 
     
 void Entanglement::initChannels(Device &satellite) {
-    Channel* sat_alice = new Channel(satellite, m_alice, m_alice_atmosphere);
-    Channel* sat_bob = new Channel(satellite, m_bob, m_bob_atmosphere);
-    addChannel(sat_alice);
-    addChannel(sat_bob);
+
+    Channel* satellite_alice = new Channel(satellite, m_alice, m_alice_atmosphere);
+    Channel* satellite_bob = new Channel(satellite, m_bob, m_bob_atmosphere);
+
+    addChannel(satellite_alice);
+    addChannel(satellite_bob);
 }
 
 void Entanglement::initChannels(Device &satellite1, Device &satellite2) {
-    
+
+    Channel* alice_satellite1 = new Channel(m_alice, satellite1, m_alice_atmosphere);
+    Channel* satellite2_satellite1 = new Channel(satellite2, satellite1);
+    Channel* satellite2_bob = new Channel(satellite2, m_bob,  m_bob_atmosphere);
+
+    addChannel(alice_satellite1);
+    addChannel(satellite2_satellite1);
+    addChannel(satellite2_bob);
 }
 
 void Entanglement::initChannels(Device &satellite1, Device &satellite2, Device &satellite3) {
     
+    Channel* satellite1_alice = new Channel(satellite1, m_alice, m_alice_atmosphere);
+    Channel* satellite1_satellite2 = new Channel(satellite1, satellite2);
+    Channel* satellite3_satellite2 = new Channel(satellite3, satellite1);
+    Channel* satellite3_bob = new Channel(satellite3, m_bob, m_bob_atmosphere);
+
+    addChannel(satellite1_alice);
+    addChannel(satellite1_satellite2);
+    addChannel(satellite3_satellite2);
+    addChannel(satellite3_bob);
 }
-
-
-/*
-void Entanglement::simulateSingleSatelliteDefault(double precision){
-    Device satellite = Device("satellite", 0.0, 0.0, m_heightAboveSeaLevel);
-
-    std::vector<double> v_qber;
-    std::vector<double> v_optical;
-    std::vector<double> v_longitude;
-
-    for (double longitude = -(MAX_LONGITUDE); longitude < MAX_LONGITUDE; longitude += precision){
-        satellite.setLatitude(getRandom(m_deviationRangeLateral));
-        satellite.setLongitude(longitude);
-        satellite.setHeightAboveSeaLevel(m_heightAboveSeaLevel + getRandom(m_deviationRangeHeight));
-
-        Channel *satellite_alice;
-        try {
-            satellite_alice = new Channel(satellite, m_alice, m_alice_atmosphere);
-        } catch (const std::runtime_error &e){
-            continue;
-        }
-
-        Channel *satellite_bob;
-        try {
-            satellite_bob = new Channel(satellite, m_bob, m_bob_atmosphere);
-        } catch (const std::runtime_error &e){
-            delete satellite_alice;
-            continue;
-        }
-
-        addChannel(satellite_alice);
-        addChannel(satellite_bob);
-
-        v_qber.push_back(getQBER());
-        v_optical.push_back(getOpticalDistance());
-        v_longitude.push_back(longitude);
-
-        // calls delete too
-        deleteChannel(satellite_alice);
-        deleteChannel(satellite_bob);
-    }
-
-    if (0 < v_qber.size()){
-        const std::string folder = makeFolder("1D", m_heightAboveSeaLevel, m_type);
-        if (folder != "ERROR"){
-            dataLogger("qber", folder, v_qber);
-            dataLogger("optical", folder, v_optical);
-            dataLogger("longitude", folder, v_longitude);
-            //etc
-        }
-    } else {
-        std::cerr << "WARNING: the network is unable to establish communication between " << m_alice.getName() <<
-            " and " << m_bob.getName() << std::endl;
-    }
-}
-
-
-void Entanglement::simulateDoubleSatelliteDefault(double precision){
-    Device satellite1 = Device("satellite_one", 0.0, 0.0, m_heightAboveSeaLevel);
-    Device satellite2 = Device("satellite_two", 0.0, 0.0, m_heightAboveSeaLevel);
-
-    std::vector<double> v_qber;
-    std::vector<double> v_optical;
-    std::vector<double> v_longitude1;
-    std::vector<double> v_longitude2;
-
-    std::vector<double> temp;
-    double count = 0;
-
-    for (double longitude1 = -(MAX_LONGITUDE); longitude1 < MAX_LONGITUDE; longitude1 += precision){
-        satellite1.setLatitude(getRandom(m_deviationRangeLateral));
-        satellite1.setLongitude(longitude1);
-        satellite1.setHeightAboveSeaLevel(m_heightAboveSeaLevel + getRandom(m_deviationRangeHeight));
-
-        for (double longitude2 = longitude1; longitude2 < MAX_LONGITUDE; longitude2 += precision){
-            satellite2.setLatitude(getRandom(m_deviationRangeLateral));
-            satellite2.setLongitude(longitude2);
-            satellite2.setHeightAboveSeaLevel(m_heightAboveSeaLevel + getRandom(m_deviationRangeHeight));
-
-            temp.push_back(count);
-            count += 1.0;
-
-            Channel *alice_satellite1;
-            try {
-                alice_satellite1 = new Channel(m_alice, satellite1, m_alice_atmosphere);
-            } catch (const std::runtime_error &e){
-                continue;
-            }
-
-            Channel *satellite2_satellite1;
-            try {
-                satellite2_satellite1 = new Channel(satellite2, satellite1);
-            } catch (const std::runtime_error &e){
-                delete alice_satellite1;
-                continue;
-            }
-
-            Channel *satellite2_bob;
-            try {
-                satellite2_bob = new Channel(satellite2, m_bob, m_bob_atmosphere);
-            } catch (const std::runtime_error &e){
-                delete alice_satellite1;
-                delete satellite2_satellite1;
-                continue;
-            }
-
-            temp.pop_back();
-
-            addChannel(alice_satellite1);
-            addChannel(satellite2_satellite1);
-            addChannel(satellite2_bob);
-
-            v_qber.push_back(getQBER());
-            v_optical.push_back(getOpticalDistance());
-            v_longitude1.push_back(longitude1);
-            v_longitude2.push_back(longitude2);
-
-            deleteChannel(alice_satellite1);
-            deleteChannel(satellite2_satellite1);
-            deleteChannel(satellite2_bob);
-        }
-    }
-
-    if (0 < v_qber.size()){
-        const std::string folder = makeFolder("2D", m_heightAboveSeaLevel, m_type);
-        if (folder != "ERROR"){
-            dataLogger("qber", folder, v_qber);
-            dataLogger("optical", folder, v_optical);
-            dataLogger("longitude1", folder, v_longitude1);
-            dataLogger("longitude2", folder, v_longitude2);
-            dataLogger("temp", folder, temp);
-            //etc
-        }
-    } else {
-        std::cerr << "WARNING: the network is unable to establish communication between " << m_alice.getName() <<
-            " and " << m_bob.getName() << std::endl;
-    }
-}
-
-
-void Entanglement::simulateTripleSatelliteDefault(double precision){
-    Device satellite1 = Device("satellite_one", 0.0, 0.0, m_heightAboveSeaLevel);
-    Device satellite2 = Device("satellite_two", 0.0, 0.0, m_heightAboveSeaLevel);
-    Device satellite3 = Device("satellite_three", 0.0, 0.0, m_heightAboveSeaLevel);
-
-    std::vector<double> v_qber;
-    std::vector<double> v_optical;
-    std::vector<double> v_longitude1;
-    std::vector<double> v_longitude2;
-    std::vector<double> v_longitude3;
-
-    for (double longitude1 = -(MAX_LONGITUDE); longitude1 < MAX_LONGITUDE; longitude1 += precision){
-        satellite1.setLatitude(getRandom(m_deviationRangeLateral));
-        satellite1.setLongitude(longitude1);
-        satellite1.setHeightAboveSeaLevel(m_heightAboveSeaLevel + getRandom(m_deviationRangeHeight));
-
-        for (double longitude2 = longitude1; longitude2 < MAX_LONGITUDE; longitude2 += precision){
-            satellite2.setLatitude(getRandom(m_deviationRangeLateral));
-            satellite2.setLongitude(longitude2);
-            satellite2.setHeightAboveSeaLevel(m_heightAboveSeaLevel + getRandom(m_deviationRangeHeight));
-
-            for (double longitude3 = longitude2; longitude3 < MAX_LONGITUDE; longitude3 += precision){
-                satellite3.setLatitude(getRandom(m_deviationRangeLateral));
-                satellite3.setLongitude(longitude3);
-                satellite3.setHeightAboveSeaLevel(m_heightAboveSeaLevel + getRandom(m_deviationRangeHeight));
-
-                Channel *satellite1_alice;
-                try {
-                    satellite1_alice = new Channel(satellite1, m_alice, m_alice_atmosphere);
-                } catch (const std::runtime_error &e){
-                    continue;
-                }
-
-                Channel *satellite1_satellite2;
-                try {
-                    satellite1_satellite2 = new Channel(satellite1, satellite2);
-                } catch (const std::runtime_error &e){
-                    delete satellite1_alice;
-                    continue;
-                }
-
-                Channel *satellite3_satellite2;
-                try {
-                    satellite3_satellite2 = new Channel(satellite3, satellite2);
-                } catch (const std::runtime_error &e){
-                    delete satellite1_alice;
-                    delete satellite1_satellite2;
-                    continue;
-                }
-
-                Channel *satellite3_bob;
-                try {
-                    satellite3_bob = new Channel(satellite3, m_bob, m_bob_atmosphere);
-                } catch (const std::runtime_error &e){
-                    delete satellite1_alice;
-                    delete satellite1_satellite2;
-                    delete satellite3_satellite2;
-                    continue;
-                }
-
-                addChannel(satellite1_alice);
-                addChannel(satellite1_satellite2);
-                addChannel(satellite3_satellite2);
-                addChannel(satellite3_bob);
-
-                v_qber.push_back(getQBER());
-                v_optical.push_back(getOpticalDistance());
-                v_longitude1.push_back(longitude1);
-                v_longitude2.push_back(longitude2);
-                v_longitude2.push_back(longitude3);
-
-                deleteChannel(satellite1_alice);
-                deleteChannel(satellite1_satellite2);
-                deleteChannel(satellite3_satellite2);
-                deleteChannel(satellite3_bob);
-            }
-        }
-    }
-
-    if (0 < v_qber.size()){
-        const std::string folder = makeFolder("3D", m_heightAboveSeaLevel, m_type);
-        if (folder != "ERROR"){
-            dataLogger("qber", folder, v_qber);
-            dataLogger("optical", folder, v_optical);
-            dataLogger("longitude1", folder, v_longitude1);
-            dataLogger("longitude2", folder, v_longitude2);
-            dataLogger("longitude3", folder, v_longitude3);
-            //etc
-        }
-    } else {
-        std::cerr << "WARNING: the network is unable to establish communication between " << m_alice.getName() <<
-            " and " << m_bob.getName() << std::endl;
-    }
-}
-*/

--- a/source/Entanglement.cpp
+++ b/source/Entanglement.cpp
@@ -19,6 +19,9 @@ double Entanglement::getQBER() const {
     return 1.0 - quantumBitSuccessRate;
 }
 
+std::string Entanglement::getType() const {
+    return "entanglement";
+}
     
 void Entanglement::initChannels(Device &satellite) {
 

--- a/source/Entanglement.cpp
+++ b/source/Entanglement.cpp
@@ -3,12 +3,6 @@
 #include "../include/Atmosphere.hpp"
 #include "../include/Channel.hpp"
 
-std::string Entanglement::m_type = "entanglement-based";
-
-std::string Entanglement::getType() const {
-    return m_type;
-}
-
 Entanglement::Entanglement(const Device &alice, const Atmosphere *alice_atmosphere, const Device &bob, const Atmosphere *bob_atmosphere, const double heightAboveSeaLevel, const double deviationRangeHeight, const double deviationRangeLateral):
     Network(alice, alice_atmosphere, bob, bob_atmosphere, heightAboveSeaLevel, deviationRangeHeight, deviationRangeLateral){
 
@@ -24,6 +18,18 @@ double Entanglement::getQBER() const {
     }
     return 1.0 - quantumBitSuccessRate;
 }
+
+    
+void Entanglement::initChannels(Device &satellite) {
+    
+}
+void Entanglement::initChannels(Device &satellite1, Device &satellite2) {
+    
+}
+void Entanglement::initChannels(Device &satellite1, Device &satellite2, Device &satellite3) {
+    
+}
+
 
 /*
 void Entanglement::simulateSingleSatelliteDefault(double precision){
@@ -78,7 +84,7 @@ void Entanglement::simulateSingleSatelliteDefault(double precision){
             " and " << m_bob.getName() << std::endl;
     }
 }
-*/
+
 
 void Entanglement::simulateDoubleSatelliteDefault(double precision){
     Device satellite1 = Device("satellite_one", 0.0, 0.0, m_heightAboveSeaLevel);
@@ -257,3 +263,4 @@ void Entanglement::simulateTripleSatelliteDefault(double precision){
             " and " << m_bob.getName() << std::endl;
     }
 }
+*/

--- a/source/Entanglement.cpp
+++ b/source/Entanglement.cpp
@@ -5,6 +5,10 @@
 
 std::string Entanglement::m_type = "entanglement-based";
 
+std::string Entanglement::getType() const {
+    return m_type;
+}
+
 Entanglement::Entanglement(const Device &alice, const Atmosphere *alice_atmosphere, const Device &bob, const Atmosphere *bob_atmosphere, const double heightAboveSeaLevel, const double deviationRangeHeight, const double deviationRangeLateral):
     Network(alice, alice_atmosphere, bob, bob_atmosphere, heightAboveSeaLevel, deviationRangeHeight, deviationRangeLateral){
 
@@ -21,6 +25,7 @@ double Entanglement::getQBER() const {
     return 1.0 - quantumBitSuccessRate;
 }
 
+/*
 void Entanglement::simulateSingleSatelliteDefault(double precision){
     Device satellite = Device("satellite", 0.0, 0.0, m_heightAboveSeaLevel);
 
@@ -73,6 +78,7 @@ void Entanglement::simulateSingleSatelliteDefault(double precision){
             " and " << m_bob.getName() << std::endl;
     }
 }
+*/
 
 void Entanglement::simulateDoubleSatelliteDefault(double precision){
     Device satellite1 = Device("satellite_one", 0.0, 0.0, m_heightAboveSeaLevel);

--- a/source/Entanglement.cpp
+++ b/source/Entanglement.cpp
@@ -21,11 +21,16 @@ double Entanglement::getQBER() const {
 
     
 void Entanglement::initChannels(Device &satellite) {
-    
+    Channel* sat_alice = new Channel(satellite, m_alice, m_alice_atmosphere);
+    Channel* sat_bob = new Channel(satellite, m_bob, m_bob_atmosphere);
+    addChannel(sat_alice);
+    addChannel(sat_bob);
 }
+
 void Entanglement::initChannels(Device &satellite1, Device &satellite2) {
     
 }
+
 void Entanglement::initChannels(Device &satellite1, Device &satellite2, Device &satellite3) {
     
 }

--- a/source/Network.cpp
+++ b/source/Network.cpp
@@ -12,10 +12,6 @@ Network::Network(const Device &alice, const Atmosphere *alice_atmosphere, const 
 Network::~Network(){
 }
 
-std::string Network::getType() const {
-    return m_type;
-}
-
 double Network::getOpticalDistance() const {
     double totalDistance = 0.0;
     for (std::vector<Channel*>::const_iterator it = m_channels.begin(); it != m_channels.end(); ++it) {

--- a/source/Network.cpp
+++ b/source/Network.cpp
@@ -102,6 +102,7 @@ void Network::simulateSingleSatellite(double precision) {
     std::vector<double> v_longitude;
 
     Device satellite = Device("satellite", 0.0, 0.0, m_heightAboveSeaLevel);
+
     initChannels(satellite); // pure virtual function with heap memory allocs
 
     for (double longitude = -(MAX_LONGITUDE); longitude < MAX_LONGITUDE; longitude += precision) {
@@ -135,3 +136,126 @@ void Network::simulateSingleSatellite(double precision) {
             " and " << m_bob.getName() << std::endl;
     }
 }
+
+void Network::simulateDoubleSatellite(double precision) {
+
+    std::vector<double> v_qber;
+    std::vector<double> v_optical; 
+    std::vector<double> v_longitude1;
+    std::vector<double> v_longitude2;
+
+    Device satellite1 = Device("satellite1", 0.0, 0.0, m_heightAboveSeaLevel);
+    Device satellite2 = Device("satellite2", 0.0, 0.0, m_heightAboveSeaLevel);
+
+    initChannels(satellite1, satellite2); // pure virtual function with heap memory allocs
+
+    for (double longitude1 = -(MAX_LONGITUDE); longitude1 < MAX_LONGITUDE; longitude1 += precision) {
+
+        satellite1.setLatitude(getRandom(m_deviationRangeLateral));
+        satellite1.setLongitude(longitude1);
+        satellite1.setHeightAboveSeaLevel(m_heightAboveSeaLevel + getRandom(m_deviationRangeHeight));
+        
+        for (double longitude2 = longitude1; longitude2 < MAX_LONGITUDE; longitude2 += precision) {
+        
+            satellite2.setLatitude(getRandom(m_deviationRangeLateral));
+            satellite2.setLongitude(longitude2);
+            satellite2.setHeightAboveSeaLevel(m_heightAboveSeaLevel + getRandom(m_deviationRangeHeight));
+
+            try {
+                updateChannels();    
+            } catch (const std::runtime_error &e) {
+                continue;
+            }
+            
+            v_qber.push_back(getQBER());
+            v_optical.push_back(getOpticalDistance());
+            v_longitude1.push_back(longitude1);
+            v_longitude2.push_back(longitude2);
+        }        
+    }
+
+    deleteChannels(); // frees the newly made channels in the pure virtual initChannels function
+    
+    if (0 < v_qber.size()){
+        const std::string folder = makeFolder("2D", m_heightAboveSeaLevel, getType());
+        if (folder != "ERROR"){
+            dataLogger("qber", folder, v_qber);
+            dataLogger("optical", folder, v_optical);
+            dataLogger("longitude1", folder, v_longitude1);
+            dataLogger("longitude2", folder, v_longitude2);
+            //etc
+        }
+    } else {
+        std::cerr << "WARNING: the network is unable to establish communication between " << m_alice.getName() <<
+            " and " << m_bob.getName() << std::endl;
+    }
+}
+
+void Network::simulateTripleSatellite(double precision) {
+
+    std::vector<double> v_qber;
+    std::vector<double> v_optical; 
+    std::vector<double> v_longitude1;
+    std::vector<double> v_longitude2;
+    std::vector<double> v_longitude3;
+
+    Device satellite1 = Device("satellite1", 0.0, 0.0, m_heightAboveSeaLevel);
+    Device satellite2 = Device("satellite2", 0.0, 0.0, m_heightAboveSeaLevel);
+    Device satellite3 = Device("satellite3", 0.0, 0.0, m_heightAboveSeaLevel);
+
+    initChannels(satellite1, satellite2, satellite3); // pure virtual function with heap memory allocs
+
+    for (double longitude1 = -(MAX_LONGITUDE); longitude1 < MAX_LONGITUDE; longitude1 += precision) {
+
+        satellite1.setLatitude(getRandom(m_deviationRangeLateral));
+        satellite1.setLongitude(longitude1);
+        satellite1.setHeightAboveSeaLevel(m_heightAboveSeaLevel + getRandom(m_deviationRangeHeight));
+        
+        for (double longitude2 = longitude1; longitude2 < MAX_LONGITUDE; longitude2 += precision) {
+        
+            satellite2.setLatitude(getRandom(m_deviationRangeLateral));
+            satellite2.setLongitude(longitude2);
+            satellite2.setHeightAboveSeaLevel(m_heightAboveSeaLevel + getRandom(m_deviationRangeHeight));
+
+            for (double longitude3 = longitude2; longitude3 < MAX_LONGITUDE; longitude3 += precision) {
+        
+                satellite3.setLatitude(getRandom(m_deviationRangeLateral));
+                satellite3.setLongitude(longitude3);
+                satellite3.setHeightAboveSeaLevel(m_heightAboveSeaLevel + getRandom(m_deviationRangeHeight));
+            
+                try {
+                    updateChannels();    
+                } catch (const std::runtime_error &e) {
+                    continue;
+                }
+                
+                v_qber.push_back(getQBER());
+                v_optical.push_back(getOpticalDistance());
+                v_longitude1.push_back(longitude1);
+                v_longitude2.push_back(longitude2);
+                v_longitude3.push_back(longitude3);
+            }
+        }
+    }
+
+    deleteChannels(); // frees the newly made channels in the pure virtual initChannels function
+    
+    if (0 < v_qber.size()){
+        const std::string folder = makeFolder("3D", m_heightAboveSeaLevel, getType());
+        if (folder != "ERROR"){
+            dataLogger("qber", folder, v_qber);
+            dataLogger("optical", folder, v_optical);
+            dataLogger("longitude1", folder, v_longitude1);
+            dataLogger("longitude2", folder, v_longitude2);
+            dataLogger("longitude3", folder, v_longitude3);
+            //etc
+        }
+    } else {
+        std::cerr << "WARNING: the network is unable to establish communication between " << m_alice.getName() <<
+            " and " << m_bob.getName() << std::endl;
+    }
+}
+
+
+    
+// TODO: make m_type consistent

--- a/source/Network.cpp
+++ b/source/Network.cpp
@@ -6,11 +6,14 @@
 #include <fstream>
 
 Network::Network(const Device &alice, const Atmosphere *alice_atmosphere, const Device &bob, const Atmosphere *bob_atmosphere, const double heightAboveSeaLevel, const double deviationRangeHeight, const double deviationRangeLateral):
-    m_alice(alice), m_alice_atmosphere(alice_atmosphere), m_bob(bob), m_bob_atmosphere(bob_atmosphere), m_heightAboveSeaLevel(heightAboveSeaLevel), m_deviationRangeHeight(deviationRangeHeight), m_deviationRangeLateral(deviationRangeLateral){
-        
+    m_alice(alice), m_alice_atmosphere(alice_atmosphere), m_bob(bob), m_bob_atmosphere(bob_atmosphere), m_heightAboveSeaLevel(heightAboveSeaLevel), m_deviationRangeHeight(deviationRangeHeight), m_deviationRangeLateral(deviationRangeLateral){        
     }
 
 Network::~Network(){
+}
+
+std::string Network::getType() const {
+    return m_type;
 }
 
 double Network::getOpticalDistance() const {

--- a/source/Network.cpp
+++ b/source/Network.cpp
@@ -46,9 +46,9 @@ void Network::deleteChannel(Channel *channel) {
 }
 
 void Network::deleteChannels() {
-    for (std::vector<Channel*>::iterator it = m_channels.end(); it !=  m_channels.begin(); --it) {
-        m_channels.erase(it);
+    for (std::vector<Channel*>::iterator it = m_channels.end() - 1; it !=  m_channels.begin(); --it) {
         delete (*it);
+        m_channels.erase(it);
     }
 }
 

--- a/source/PrepareAndMeasure.cpp
+++ b/source/PrepareAndMeasure.cpp
@@ -3,8 +3,6 @@
 #include "../include/Atmosphere.hpp"
 #include "../include/Channel.hpp"
 
-std::string PrepareAndMeasure::m_type = "prepare-and-measure";
-
 PrepareAndMeasure::PrepareAndMeasure(const Device &alice, const Atmosphere *alice_atmosphere, const Device &bob, const Atmosphere *bob_atmosphere, const double heightAboveSeaLevel, const double deviationRangeHeight, const double deviationRangeLateral):
     Network(alice, alice_atmosphere, bob, bob_atmosphere, heightAboveSeaLevel, deviationRangeHeight, deviationRangeLateral){
 
@@ -26,6 +24,19 @@ double PrepareAndMeasure::getQBER() const {
     return quantumBitErrorRate;
 }
 
+    
+void PrepareAndMeasure::initChannels(Device &satellite) {
+    
+}
+void PrepareAndMeasure::initChannels(Device &satellite1, Device &satellite2) {
+    
+}
+void PrepareAndMeasure::initChannels(Device &satellite1, Device &satellite2, Device &satellite3) {
+    
+}
+
+
+/*
 void PrepareAndMeasure::simulateSingleSatelliteDefault(double precision){
     Device satellite = Device("satellite", 0.0, 0.0, m_heightAboveSeaLevel);
 
@@ -246,3 +257,4 @@ void PrepareAndMeasure::simulateTripleSatelliteDefault(double precision){
             " and " << m_bob.getName() << std::endl;
     }
 }
+*/

--- a/source/PrepareAndMeasure.cpp
+++ b/source/PrepareAndMeasure.cpp
@@ -27,234 +27,33 @@ double PrepareAndMeasure::getQBER() const {
     
 void PrepareAndMeasure::initChannels(Device &satellite) {
     
+    Channel* alice_satellite = new Channel(m_alice, satellite, m_alice_atmosphere);
+    Channel* satellite_bob = new Channel(satellite, m_bob, m_bob_atmosphere);
+
+    addChannel(alice_satellite);
+    addChannel(satellite_bob);
+    
 }
 void PrepareAndMeasure::initChannels(Device &satellite1, Device &satellite2) {
     
+    Channel* alice_satellite1 = new Channel(m_alice, satellite1, m_alice_atmosphere);
+    Channel* satellite1_satellite2 = new Channel(satellite1, satellite2);
+    Channel* satellite2_bob = new Channel(satellite2, m_bob,  m_bob_atmosphere);
+
+    addChannel(alice_satellite1);
+    addChannel(satellite1_satellite2);
+    addChannel(satellite2_bob);
+   
 }
 void PrepareAndMeasure::initChannels(Device &satellite1, Device &satellite2, Device &satellite3) {
     
+    Channel* alice_satellite1 = new Channel(m_alice, satellite1, m_alice_atmosphere);
+    Channel* satellite1_satellite2 = new Channel(satellite1, satellite2);
+    Channel* satellite2_satellite3 = new Channel(satellite2, satellite3);
+    Channel* satellite3_bob = new Channel(satellite3, m_bob, m_bob_atmosphere);
+
+    addChannel(alice_satellite1);
+    addChannel(satellite1_satellite2);
+    addChannel(satellite2_satellite3);
+    addChannel(satellite3_bob);
 }
-
-
-/*
-void PrepareAndMeasure::simulateSingleSatelliteDefault(double precision){
-    Device satellite = Device("satellite", 0.0, 0.0, m_heightAboveSeaLevel);
-
-    std::vector<double> v_qber;
-    std::vector<double> v_optical;
-    std::vector<double> v_longitude;
-
-    for (double longitude = -(MAX_LONGITUDE); longitude < MAX_LONGITUDE; longitude += precision){
-        satellite.setLatitude(getRandom(m_deviationRangeLateral));
-        satellite.setLongitude(longitude);
-        satellite.setHeightAboveSeaLevel(m_heightAboveSeaLevel + getRandom(m_deviationRangeHeight));
-
-        Channel *alice_satellite;
-        try {
-            alice_satellite = new Channel(m_alice, satellite, m_alice_atmosphere);
-        } catch (const std::runtime_error &e){
-            continue;
-        }
-
-        Channel *satellite_bob;
-        try {
-            satellite_bob = new Channel(satellite, m_bob, m_bob_atmosphere);
-        } catch (const std::runtime_error &e){
-            delete alice_satellite;
-            continue;
-        }
-
-        addChannel(alice_satellite);
-        addChannel(satellite_bob);
-
-        v_qber.push_back(getQBER());
-        v_optical.push_back(getOpticalDistance());
-        v_longitude.push_back(longitude);
-
-        deleteChannel(alice_satellite);
-        deleteChannel(satellite_bob);
-    }
-
-    if (0 < v_qber.size()){
-        const std::string folder = makeFolder("1D", m_heightAboveSeaLevel, m_type);
-        if (folder != "ERROR"){
-            dataLogger("qber", folder, v_qber);
-            dataLogger("optical", folder, v_optical);
-            dataLogger("longitude", folder, v_longitude);
-            //etc
-        }
-    } else {
-        std::cerr << "WARNING: the network is unable to establish communication between " << m_alice.getName() <<
-            " and " << m_bob.getName() << std::endl;
-    }
-
-}
-
-void PrepareAndMeasure::simulateDoubleSatelliteDefault(double precision){
-    Device satellite1 = Device("satellite_one", 0.0, 0.0, m_heightAboveSeaLevel);
-    Device satellite2 = Device("satellite_two", 0.0, 0.0, m_heightAboveSeaLevel);
-
-    std::vector<double> v_qber;
-    std::vector<double> v_optical;
-    std::vector<double> v_longitude1;
-    std::vector<double> v_longitude2;
-
-    for (double longitude1 = -(MAX_LONGITUDE); longitude1 < MAX_LONGITUDE; longitude1 += precision){
-        satellite1.setLatitude(getRandom(m_deviationRangeLateral));
-        satellite1.setLongitude(longitude1);
-        satellite1.setHeightAboveSeaLevel(m_heightAboveSeaLevel + getRandom(m_deviationRangeHeight));
-
-        for (double longitude2 = longitude1; longitude2 < MAX_LONGITUDE; longitude2 += precision){
-            satellite2.setLatitude(getRandom(m_deviationRangeLateral));
-            satellite2.setLongitude(longitude2);
-            satellite2.setHeightAboveSeaLevel(m_heightAboveSeaLevel + getRandom(m_deviationRangeHeight));
-
-            Channel *alice_satellite1;
-            try {
-                alice_satellite1 = new Channel(m_alice, satellite1, m_alice_atmosphere);
-            } catch (const std::runtime_error &e){
-                continue;
-            }
-
-            Channel *satellite1_satellite2;
-            try {
-                satellite1_satellite2 = new Channel(satellite1, satellite2);
-            } catch (const std::runtime_error &e){
-                delete alice_satellite1;
-                continue;
-            }
-
-            Channel *satellite2_bob;
-            try {
-                satellite2_bob = new Channel(satellite2, m_bob, m_bob_atmosphere);
-            } catch (const std::runtime_error &e){
-                delete alice_satellite1;
-                delete satellite1_satellite2;
-                continue;
-            }
-
-            addChannel(alice_satellite1);
-            addChannel(satellite1_satellite2);
-            addChannel(satellite2_bob);
-
-            v_qber.push_back(getQBER());
-            v_optical.push_back(getOpticalDistance());
-            v_longitude1.push_back(longitude1);
-            v_longitude2.push_back(longitude2);
-
-            deleteChannel(alice_satellite1);
-            deleteChannel(satellite1_satellite2);
-            deleteChannel(satellite2_bob);
-        }
-    }
-    if (0 < v_qber.size()){
-        const std::string folder = makeFolder("1D", m_heightAboveSeaLevel, m_type);
-        if (folder != "ERROR"){
-            dataLogger("qber", folder, v_qber);
-            dataLogger("optical", folder, v_optical);
-            dataLogger("longitude", folder, v_longitude1);
-            dataLogger("longitude", folder, v_longitude2);
-            //etc
-        }
-    } else {
-        std::cerr << "WARNING: the network is unable to establish communication between " << m_alice.getName() <<
-            " and " << m_bob.getName() << std::endl;
-    }
-}
-
-void PrepareAndMeasure::simulateTripleSatelliteDefault(double precision){
-    Device satellite1 = Device("satellite_one", 0.0, 0.0, m_heightAboveSeaLevel);
-    Device satellite2 = Device("satellite_two", 0.0, 0.0, m_heightAboveSeaLevel);
-    Device satellite3 = Device("satellite_three", 0.0, 0.0, m_heightAboveSeaLevel);
-
-    std::vector<double> v_qber;
-    std::vector<double> v_optical;
-    std::vector<double> v_longitude1;
-    std::vector<double> v_longitude2;
-    std::vector<double> v_longitude3;
-
-    for (double longitude1 = -(MAX_LONGITUDE); longitude1 < MAX_LONGITUDE; longitude1 += precision){
-        satellite1.setLatitude(getRandom(m_deviationRangeLateral));
-        satellite1.setLongitude(longitude1);
-        satellite1.setHeightAboveSeaLevel(m_heightAboveSeaLevel + getRandom(m_deviationRangeHeight));
-
-        for (double longitude2 = longitude1; longitude2 < MAX_LONGITUDE; longitude2 += precision){
-            satellite2.setLatitude(getRandom(m_deviationRangeLateral));
-            satellite2.setLongitude(longitude2);
-            satellite2.setHeightAboveSeaLevel(m_heightAboveSeaLevel + getRandom(m_deviationRangeHeight));
-
-            for (double longitude3 = longitude2; longitude3 < MAX_LONGITUDE; longitude3 += precision){
-                satellite3.setLatitude(getRandom(m_deviationRangeLateral));
-                satellite3.setLongitude(longitude3);
-                satellite3.setHeightAboveSeaLevel(m_heightAboveSeaLevel + getRandom(m_deviationRangeHeight));
-
-
-                Channel *alice_satellite1;
-                try {
-                    alice_satellite1 = new Channel(m_alice, satellite1, m_alice_atmosphere);
-                } catch (const std::runtime_error &e){
-                    continue;
-                }
-
-                Channel *satellite1_satellite2;
-                try {
-                    satellite1_satellite2 = new Channel(satellite1, satellite2);
-                } catch (const std::runtime_error &e){
-                    delete alice_satellite1;
-                    continue;
-                }
-
-                Channel *satellite2_satellite3;
-                try {
-                    satellite2_satellite3 = new Channel(satellite2, satellite3);
-                } catch (const std::runtime_error &e){
-                    delete alice_satellite1;
-                    delete satellite1_satellite2;
-                    continue;
-                }
-
-                Channel *satellite3_bob;
-                try {
-                    satellite3_bob = new Channel(satellite3, m_bob, m_bob_atmosphere);
-                } catch (const std::runtime_error &e){
-                    delete alice_satellite1;
-                    delete satellite1_satellite2;
-                    delete satellite2_satellite3;
-                    continue;
-                }
-
-                addChannel(alice_satellite1);
-                addChannel(satellite1_satellite2);
-                addChannel(satellite2_satellite3);
-                addChannel(satellite3_bob);
-
-                v_qber.push_back(getQBER());
-                v_optical.push_back(getOpticalDistance());
-                v_longitude1.push_back(longitude1);
-                v_longitude2.push_back(longitude2);
-                v_longitude2.push_back(longitude3);
-
-                deleteChannel(alice_satellite1);
-                deleteChannel(satellite1_satellite2);
-                deleteChannel(satellite2_satellite3);
-                deleteChannel(satellite3_bob);
-            }
-        }
-    }
-
-    if (0 < v_qber.size()){
-        const std::string folder = makeFolder("3D", m_heightAboveSeaLevel, m_type);
-        if (folder != "ERROR"){
-            dataLogger("qber", folder, v_qber);
-            dataLogger("optical", folder, v_optical);
-            dataLogger("longitude1", folder, v_longitude1);
-            dataLogger("longitude2", folder, v_longitude2);
-            dataLogger("longitude3", folder, v_longitude3);
-            //etc
-        }
-    } else {
-        std::cerr << "WARNING: the network is unable to establish communication between " << m_alice.getName() <<
-            " and " << m_bob.getName() << std::endl;
-    }
-}
-*/

--- a/source/PrepareAndMeasure.cpp
+++ b/source/PrepareAndMeasure.cpp
@@ -24,6 +24,9 @@ double PrepareAndMeasure::getQBER() const {
     return quantumBitErrorRate;
 }
 
+std::string PrepareAndMeasure::getType() const {
+    return "prepare-and-measure";
+}
     
 void PrepareAndMeasure::initChannels(Device &satellite) {
     
@@ -34,6 +37,7 @@ void PrepareAndMeasure::initChannels(Device &satellite) {
     addChannel(satellite_bob);
     
 }
+
 void PrepareAndMeasure::initChannels(Device &satellite1, Device &satellite2) {
     
     Channel* alice_satellite1 = new Channel(m_alice, satellite1, m_alice_atmosphere);

--- a/source/Simulate.cpp
+++ b/source/Simulate.cpp
@@ -14,7 +14,7 @@ int main(void){
     const Device bob = Device("bob", 0.0, 8.0);
 
     Entanglement ent = Entanglement(alice, &alice_atm, bob, &alice_atm, 500.0, 25.0, 0.1);
-    ent.simulateDoubleSatelliteDefault(1.0);
+    //ent.simulateDoubleSatelliteDefault(1.0);
 
     return 0;
 }

--- a/source/Simulate.cpp
+++ b/source/Simulate.cpp
@@ -11,10 +11,10 @@ int main(void){
     const Atmosphere alice_atm = Atmosphere("Midlatitude", "Summer", "Clear");
     const Atmosphere bob_atm = Atmosphere("Tropical", "Summer", "Hazy");
     const Device alice = Device("alice", 0.0, 0.0);
-    const Device bob = Device("bob", 0.0, 8.0);
+    const Device bob = Device("bob", 0.0, 3.0);
 
     Entanglement ent = Entanglement(alice, &alice_atm, bob, &alice_atm, 500.0, 25.0, 0.1);
-    //ent.simulateDoubleSatelliteDefault(1.0);
+    ent.simulateSingleSatellite(1.0);
 
     return 0;
 }


### PR DESCRIPTION
Migrates the simulation functionality to the parent Network class from the child Entanglement and PrepareAndMeasure classes for less redundancy.